### PR TITLE
kafka/quota_mgr: extract keys and limit logic into `quota_translator`

### DIFF
--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -48,6 +48,7 @@ v_cc_library(
     server/server.cc
     server/protocol_utils.cc
     server/quota_manager.cc
+    server/quota_translator.cc
     server/snc_quota_manager.cc
     server/fetch_session_cache.cc
     server/replicated_partition.cc

--- a/src/v/kafka/server/quota_manager.cc
+++ b/src/v/kafka/server/quota_manager.cc
@@ -15,6 +15,7 @@
 #include "container/fragmented_vector.h"
 #include "kafka/server/atomic_token_bucket.h"
 #include "kafka/server/logger.h"
+#include "kafka/server/quota_translator.h"
 #include "ssx/future-util.h"
 
 #include <seastar/core/future.hh>
@@ -35,36 +36,20 @@ using namespace std::chrono_literals;
 namespace kafka {
 
 using clock = quota_manager::clock;
-using k_client_id = quota_manager::k_client_id;
-using k_group_name = quota_manager::k_group_name;
-using tracker_key = quota_manager::tracker_key;
 
 quota_manager::quota_manager(client_quotas_t& client_quotas)
   : _default_num_windows(config::shard_local_cfg().default_num_windows.bind())
   , _default_window_width(config::shard_local_cfg().default_window_sec.bind())
   , _replenish_threshold(
       config::shard_local_cfg().kafka_throughput_replenish_threshold.bind())
-  , _default_target_produce_tp_rate(
-      config::shard_local_cfg().target_quota_byte_rate.bind())
-  , _default_target_fetch_tp_rate(
-      config::shard_local_cfg().target_fetch_quota_byte_rate.bind())
-  , _target_partition_mutation_quota(
-      config::shard_local_cfg().kafka_admin_topic_api_rate.bind())
-  , _target_produce_tp_rate_per_client_group(
-      config::shard_local_cfg().kafka_client_group_byte_rate_quota.bind())
-  , _target_fetch_tp_rate_per_client_group(
-      config::shard_local_cfg().kafka_client_group_fetch_byte_rate_quota.bind())
   , _client_quotas{client_quotas}
+  , _translator{}
   , _gc_freq(config::shard_local_cfg().quota_manager_gc_sec())
   , _max_delay(config::shard_local_cfg().max_kafka_throttle_delay_ms.bind()) {
     if (seastar::this_shard_id() == _client_quotas.shard_id()) {
         _gc_timer.set_callback([this]() { gc(); });
         auto update_quotas = [this]() { update_client_quotas(); };
-        _target_produce_tp_rate_per_client_group.watch(update_quotas);
-        _target_fetch_tp_rate_per_client_group.watch(update_quotas);
-        _target_partition_mutation_quota.watch(update_quotas);
-        _default_target_produce_tp_rate.watch(update_quotas);
-        _default_target_fetch_tp_rate.watch(update_quotas);
+        _translator.watch(update_quotas);
     }
 }
 
@@ -121,9 +106,7 @@ quota_manager::add_quota_id(tracker_key qid, clock::time_point now) {
 
     auto update_func =
       [this, qid, now](client_quotas_map_t new_map) -> client_quotas_map_t {
-        auto produce_rate = get_client_target_produce_tp_rate(qid);
-        auto fetch_rate = get_client_target_fetch_tp_rate(qid);
-        auto partition_mutation_rate = _target_partition_mutation_quota();
+        auto limits = _translator.find_quota_value(qid);
         auto replenish_threshold = static_cast<uint64_t>(
           _replenish_threshold().value_or(1));
 
@@ -133,16 +116,24 @@ quota_manager::add_quota_id(tracker_key qid, clock::time_point now) {
           std::nullopt,
           std::nullopt);
 
-        new_value->tp_produce_rate.emplace(
-          produce_rate, produce_rate, replenish_threshold, true);
-        if (fetch_rate.has_value()) {
-            new_value->tp_fetch_rate.emplace(
-              *fetch_rate, *fetch_rate, replenish_threshold, true);
+        if (limits.produce_limit.has_value()) {
+            new_value->tp_produce_rate.emplace(
+              *limits.produce_limit,
+              *limits.produce_limit,
+              replenish_threshold,
+              true);
         }
-        if (partition_mutation_rate.has_value()) {
+        if (limits.fetch_limit.has_value()) {
+            new_value->tp_fetch_rate.emplace(
+              *limits.fetch_limit,
+              *limits.fetch_limit,
+              replenish_threshold,
+              true);
+        }
+        if (limits.partition_mutation_limit.has_value()) {
             new_value->pm_rate.emplace(
-              *partition_mutation_rate,
-              *partition_mutation_rate,
+              *limits.partition_mutation_limit,
+              *limits.partition_mutation_limit,
               replenish_threshold,
               true);
         }
@@ -179,85 +170,26 @@ void quota_manager::update_client_quotas() {
               };
 
             for (auto& quota : quotas) {
+                auto limits = _translator.find_quota_value(quota.first);
                 set_bucket(
                   quota.second->tp_produce_rate,
-                  get_client_target_produce_tp_rate(quota.first),
+                  limits.produce_limit,
                   _replenish_threshold());
 
                 set_bucket(
                   quota.second->tp_fetch_rate,
-                  get_client_target_fetch_tp_rate(quota.first),
+                  limits.fetch_limit,
                   _replenish_threshold());
 
                 set_bucket(
                   quota.second->pm_rate,
-                  _target_partition_mutation_quota(),
+                  limits.partition_mutation_limit,
                   _replenish_threshold());
             }
 
             return quotas;
         });
     });
-}
-
-// If client is part of some group then client quota ID is a group
-// else client quota ID is client_id
-static tracker_key get_client_quota_id(
-  const std::optional<std::string_view>& client_id,
-  const std::unordered_map<ss::sstring, config::client_group_quota>&
-    group_quota) {
-    if (!client_id) {
-        // requests without a client id are grouped into an anonymous group that
-        // shares a default quota. the anonymous group is keyed on empty string.
-        return k_client_id{""};
-    }
-    for (const auto& group_and_limit : group_quota) {
-        if (client_id->starts_with(
-              std::string_view(group_and_limit.second.clients_prefix))) {
-            return k_group_name{group_and_limit.first};
-        }
-    }
-    return k_client_id{*client_id};
-}
-
-int64_t
-quota_manager::get_client_target_produce_tp_rate(const tracker_key& quota_id) {
-    return std::visit(
-      [this](const auto& qid) -> int64_t {
-          using T = std::decay_t<decltype(qid)>;
-          if constexpr (std::is_same_v<k_client_id, T>) {
-              return _default_target_produce_tp_rate();
-          } else if constexpr (std::is_same_v<k_group_name, T>) {
-              auto group = _target_produce_tp_rate_per_client_group().find(qid);
-              if (group != _target_produce_tp_rate_per_client_group().end()) {
-                  return group->second.quota;
-              }
-              return _default_target_produce_tp_rate();
-          } else {
-              static_assert(always_false_v<T>, "Unknown tracker_key type");
-          }
-      },
-      quota_id);
-}
-
-std::optional<int64_t>
-quota_manager::get_client_target_fetch_tp_rate(const tracker_key& quota_id) {
-    return std::visit(
-      [this](const auto& qid) -> std::optional<int64_t> {
-          using T = std::decay_t<decltype(qid)>;
-          if constexpr (std::is_same_v<k_client_id, T>) {
-              return _default_target_fetch_tp_rate();
-          } else if constexpr (std::is_same_v<k_group_name, T>) {
-              auto group = _target_fetch_tp_rate_per_client_group().find(qid);
-              if (group != _target_fetch_tp_rate_per_client_group().end()) {
-                  return group->second.quota;
-              }
-              return _default_target_fetch_tp_rate();
-          } else {
-              static_assert(always_false_v<T>, "Unknown tracker_key type");
-          }
-      },
-      quota_id);
 }
 
 ss::future<std::chrono::milliseconds> quota_manager::record_partition_mutations(
@@ -267,13 +199,14 @@ ss::future<std::chrono::milliseconds> quota_manager::record_partition_mutations(
     /// KIP-599 throttles create_topics / delete_topics / create_partitions
     /// request. This delay should only be applied to these requests if the
     /// quota has been exceeded
-    if (!_target_partition_mutation_quota()) {
+    auto key = _translator.get_partition_mutation_key(client_id);
+    auto limits = _translator.find_quota_value(key);
+    if (!limits.partition_mutation_limit) {
         co_return 0ms;
     }
 
-    auto quota_id = get_client_quota_id(client_id, {});
     auto delay = co_await maybe_add_and_retrieve_quota(
-      quota_id, now, [now, mutations](quota_manager::client_quota& cq) {
+      key, now, [now, mutations](quota_manager::client_quota& cq) {
           if (!cq.pm_rate.has_value()) {
               return clock::duration::zero();
           }
@@ -286,7 +219,7 @@ ss::future<std::chrono::milliseconds> quota_manager::record_partition_mutations(
       });
 
     co_return duration_cast<std::chrono::milliseconds>(
-      cap_to_max_delay(quota_id, delay));
+      cap_to_max_delay(key, delay));
 }
 
 clock::duration quota_manager::cap_to_max_delay(
@@ -311,14 +244,13 @@ ss::future<clock::duration> quota_manager::record_produce_tp_and_throttle(
   std::optional<std::string_view> client_id,
   uint64_t bytes,
   clock::time_point now) {
-    auto quota_id = get_client_quota_id(
-      client_id, _target_produce_tp_rate_per_client_group());
-    auto produce_limit = get_client_target_produce_tp_rate(quota_id);
-    if (!produce_limit) {
+    auto key = _translator.get_produce_key(client_id);
+    auto limits = _translator.find_quota_value(key);
+    if (!limits.produce_limit) {
         co_return clock::duration::zero();
     }
     auto delay = co_await maybe_add_and_retrieve_quota(
-      quota_id, now, [now, bytes](quota_manager::client_quota& cq) {
+      key, now, [now, bytes](quota_manager::client_quota& cq) {
           if (!cq.tp_produce_rate.has_value()) {
               return clock::duration::zero();
           }
@@ -327,21 +259,20 @@ ss::future<clock::duration> quota_manager::record_produce_tp_and_throttle(
             now, bytes);
       });
 
-    co_return cap_to_max_delay(quota_id, delay);
+    co_return cap_to_max_delay(key, delay);
 }
 
 ss::future<> quota_manager::record_fetch_tp(
   std::optional<std::string_view> client_id,
   uint64_t bytes,
   clock::time_point now) {
-    auto quota_id = get_client_quota_id(
-      client_id, _target_fetch_tp_rate_per_client_group());
-    auto fetch_limit = get_client_target_fetch_tp_rate(quota_id);
-    if (!fetch_limit) {
+    auto key = _translator.get_fetch_key(client_id);
+    auto limits = _translator.find_quota_value(key);
+    if (!limits.fetch_limit) {
         co_return;
     }
     auto delay [[maybe_unused]] = co_await maybe_add_and_retrieve_quota(
-      quota_id, now, [bytes](quota_manager::client_quota& cq) {
+      key, now, [bytes](quota_manager::client_quota& cq) {
           if (!cq.tp_fetch_rate.has_value()) {
               return clock::duration::zero();
           }
@@ -353,14 +284,14 @@ ss::future<> quota_manager::record_fetch_tp(
 
 ss::future<clock::duration> quota_manager::throttle_fetch_tp(
   std::optional<std::string_view> client_id, clock::time_point now) {
-    auto quota_id = get_client_quota_id(
-      client_id, _target_fetch_tp_rate_per_client_group());
-    if (!get_client_target_fetch_tp_rate(quota_id)) {
+    auto key = _translator.get_fetch_key(client_id);
+    auto limits = _translator.find_quota_value(key);
+    if (!limits.fetch_limit) {
         co_return clock::duration::zero();
     }
 
     auto delay = co_await maybe_add_and_retrieve_quota(
-      quota_id, now, [now](quota_manager::client_quota& cq) {
+      key, now, [now](quota_manager::client_quota& cq) {
           if (!cq.tp_fetch_rate.has_value()) {
               return clock::duration::zero();
           }
@@ -368,7 +299,7 @@ ss::future<clock::duration> quota_manager::throttle_fetch_tp(
           return fetch_tracker.update_and_calculate_delay<clock::duration>(now);
       });
 
-    co_return cap_to_max_delay(quota_id, delay);
+    co_return cap_to_max_delay(key, delay);
 }
 
 // erase inactive tracked quotas. windows are considered inactive if

--- a/src/v/kafka/server/quota_manager.h
+++ b/src/v/kafka/server/quota_manager.h
@@ -14,6 +14,7 @@
 #include "config/client_group_byte_rate_quota.h"
 #include "config/property.h"
 #include "kafka/server/atomic_token_bucket.h"
+#include "kafka/server/quota_translator.h"
 #include "ssx/sharded_ptr.h"
 #include "ssx/sharded_value.h"
 #include "utils/absl_sstring_hash.h"
@@ -55,16 +56,6 @@ namespace kafka {
 class quota_manager : public ss::peering_sharded_service<quota_manager> {
 public:
     using clock = ss::lowres_clock;
-
-    using k_client_id = named_type<ss::sstring, struct k_client_id_tag>;
-    using k_group_name = named_type<ss::sstring, struct k_group_name_tag>;
-
-    /// tracker_key is the we use to key into the client quotas map
-    /// Note: if the default quota applies to the request, the tracker_key will
-    /// still be client id specific. In that case, the rate trackers of each
-    /// client will have the same (default) limit, but the rate trackers will be
-    /// independent.
-    using tracker_key = std::variant<k_client_id, k_group_name>;
 
     // Accounting for quota on per-client and per-client-group basis
     // last_seen_ms: used for gc keepalive
@@ -138,21 +129,13 @@ private:
       quota_mutation_callback_t cb);
     ss::future<> add_quota_id(tracker_key quota_id, clock::time_point now);
     void update_client_quotas();
-    int64_t get_client_target_produce_tp_rate(const tracker_key& quota_id);
-    std::optional<int64_t>
-    get_client_target_fetch_tp_rate(const tracker_key& quota_id);
 
     config::binding<int16_t> _default_num_windows;
     config::binding<std::chrono::milliseconds> _default_window_width;
     config::binding<std::optional<int64_t>> _replenish_threshold;
 
-    config::binding<uint32_t> _default_target_produce_tp_rate;
-    config::binding<std::optional<uint32_t>> _default_target_fetch_tp_rate;
-    config::binding<std::optional<uint32_t>> _target_partition_mutation_quota;
-    config::binding<quota_config> _target_produce_tp_rate_per_client_group;
-    config::binding<quota_config> _target_fetch_tp_rate_per_client_group;
-
     client_quotas_t& _client_quotas;
+    quota_translator _translator;
 
     ss::timer<> _gc_timer;
     clock::duration _gc_freq;

--- a/src/v/kafka/server/quota_translator.cc
+++ b/src/v/kafka/server/quota_translator.cc
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/server/quota_translator.h"
+
+#include "config/configuration.h"
+
+#include <optional>
+
+namespace kafka {
+
+quota_translator::quota_translator()
+  : _default_target_produce_tp_rate(
+    config::shard_local_cfg().target_quota_byte_rate.bind())
+  , _default_target_fetch_tp_rate(
+      config::shard_local_cfg().target_fetch_quota_byte_rate.bind())
+  , _target_partition_mutation_quota(
+      config::shard_local_cfg().kafka_admin_topic_api_rate.bind())
+  , _target_produce_tp_rate_per_client_group(
+      config::shard_local_cfg().kafka_client_group_byte_rate_quota.bind())
+  , _target_fetch_tp_rate_per_client_group(
+      config::shard_local_cfg()
+        .kafka_client_group_fetch_byte_rate_quota.bind()) {
+    auto update_quotas = [this]() {
+        if (_on_change) {
+            (*_on_change)();
+        }
+    };
+    _target_produce_tp_rate_per_client_group.watch(update_quotas);
+    _target_fetch_tp_rate_per_client_group.watch(update_quotas);
+    _target_partition_mutation_quota.watch(update_quotas);
+    _default_target_produce_tp_rate.watch(update_quotas);
+    _default_target_fetch_tp_rate.watch(update_quotas);
+}
+
+int64_t quota_translator::get_client_target_produce_tp_rate(
+  const tracker_key& quota_id) {
+    return std::visit(
+      [this](const auto& qid) -> int64_t {
+          using T = std::decay_t<decltype(qid)>;
+          if constexpr (std::is_same_v<k_client_id, T>) {
+              return _default_target_produce_tp_rate();
+          } else if constexpr (std::is_same_v<k_group_name, T>) {
+              auto group = _target_produce_tp_rate_per_client_group().find(qid);
+              if (group != _target_produce_tp_rate_per_client_group().end()) {
+                  return group->second.quota;
+              }
+              return _default_target_produce_tp_rate();
+          } else {
+              static_assert(always_false_v<T>, "Unknown tracker_key type");
+          }
+      },
+      quota_id);
+}
+
+std::optional<int64_t>
+quota_translator::get_client_target_fetch_tp_rate(const tracker_key& quota_id) {
+    return std::visit(
+      [this](const auto& qid) -> std::optional<int64_t> {
+          using T = std::decay_t<decltype(qid)>;
+          if constexpr (std::is_same_v<k_client_id, T>) {
+              return _default_target_fetch_tp_rate();
+          } else if constexpr (std::is_same_v<k_group_name, T>) {
+              auto group = _target_fetch_tp_rate_per_client_group().find(qid);
+              if (group != _target_fetch_tp_rate_per_client_group().end()) {
+                  return group->second.quota;
+              }
+              return _default_target_fetch_tp_rate();
+          } else {
+              static_assert(always_false_v<T>, "Unknown tracker_key type");
+          }
+      },
+      quota_id);
+}
+
+namespace {
+// If client is part of some group then client quota ID is a group
+// else client quota ID is client_id
+tracker_key get_client_quota_id(
+  const std::optional<std::string_view>& client_id,
+  const std::unordered_map<ss::sstring, config::client_group_quota>&
+    group_quota) {
+    if (!client_id) {
+        // requests without a client id are grouped into an anonymous group that
+        // shares a default quota. the anonymous group is keyed on empty string.
+        return k_client_id{""};
+    }
+    for (const auto& group_and_limit : group_quota) {
+        if (client_id->starts_with(
+              std::string_view(group_and_limit.second.clients_prefix))) {
+            return k_group_name{group_and_limit.first};
+        }
+    }
+    return k_client_id{*client_id};
+}
+
+} // namespace
+
+tracker_key quota_translator::get_produce_key(
+  const std::optional<std::string_view>& client_id) {
+    return get_client_quota_id(
+      client_id, _target_produce_tp_rate_per_client_group());
+}
+
+tracker_key quota_translator::get_fetch_key(
+  const std::optional<std::string_view>& client_id) {
+    return get_client_quota_id(
+      client_id, _target_fetch_tp_rate_per_client_group());
+}
+
+tracker_key quota_translator::get_partition_mutation_key(
+  const std::optional<std::string_view>& client_id) {
+    return get_client_quota_id(client_id, {});
+}
+
+quota_limits quota_translator::find_quota_value(const tracker_key& key) {
+    return quota_limits{
+      .produce_limit = get_client_target_produce_tp_rate(key),
+      .fetch_limit = get_client_target_fetch_tp_rate(key),
+      .partition_mutation_limit = _target_partition_mutation_quota(),
+    };
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/quota_translator.cc
+++ b/src/v/kafka/server/quota_translator.cc
@@ -17,6 +17,17 @@
 
 namespace kafka {
 
+std::ostream& operator<<(std::ostream& os, const quota_limits& l) {
+    fmt::print(
+      os,
+      "limits{{produce_limit: {}, fetch_limit: {}, "
+      "partition_mutation_limit: {}}}",
+      l.produce_limit,
+      l.fetch_limit,
+      l.partition_mutation_limit);
+    return os;
+}
+
 quota_translator::quota_translator()
   : _default_target_produce_tp_rate(
     config::shard_local_cfg().target_quota_byte_rate.bind())

--- a/src/v/kafka/server/quota_translator.h
+++ b/src/v/kafka/server/quota_translator.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "config/client_group_byte_rate_quota.h"
+#include "config/property.h"
+#include "utils/named_type.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <utility>
+
+namespace kafka {
+
+using k_client_id = named_type<ss::sstring, struct k_client_id_tag>;
+using k_group_name = named_type<ss::sstring, struct k_group_name_tag>;
+
+/// tracker_key is the we use to key into the client quotas map
+///
+/// Note: while the limits applicable to a single tracker_key are always going
+/// to be the same, it is not guaranteed that a client id will have the same
+/// tracker_key for different types of kafka requests (produce/fetch/partition
+/// mutations). For examples, refer to the unit tests.
+///
+/// Note: the tracker_key is different from the entity_key used to configure
+/// client quotas. The tracker_key defines the granularity at which we track
+/// quotas, whereas the quota limits might be defined more broadly.
+/// For example, if the default client quota applies to the request, the
+/// tracker_key may be client id specific even though the matching entity_key is
+/// the default client quota. In this case, we may have multiple independent
+/// rate trackers for each unique client with all of these rate tracking having
+/// the same shared quota limit
+using tracker_key = std::variant<k_client_id, k_group_name>;
+
+/// quota_limits describes the limits applicable to a tracker_key
+struct quota_limits {
+    std::optional<uint64_t> produce_limit;
+    std::optional<uint64_t> fetch_limit;
+    std::optional<uint64_t> partition_mutation_limit;
+};
+
+/// quota_translator is responsible for providing quota_manager with a
+/// simplified interface to the quota configurations
+///  * It is responsible for translating the quota-specific request context (for
+///  now the client.id header field) into the applicable tracker_key.
+///  * It is also responsible for finding the quota limits of a tracker_key
+class quota_translator {
+public:
+    using on_change_fn = std::function<void()>;
+
+    quota_translator();
+
+    /// Returns the quota tracker key used for produce requests
+    /// Note: because the client quotas configured for produce/fetch/pm might be
+    /// different, the tracker_key for produce/fetch/pm might be different
+    tracker_key
+    get_produce_key(const std::optional<std::string_view>& client_id);
+
+    /// Returns the quota tracker key used for fetch requests
+    /// Note: because the client quotas configured for produce/fetch/pm might be
+    /// different, the tracker_key for produce/fetch/pm might be different
+    tracker_key get_fetch_key(const std::optional<std::string_view>& client_id);
+
+    /// Returns the quota tracker key used for partition mutation requests
+    /// Note: because the client quotas configured for produce/fetch/pm might be
+    /// different, the tracker_key for produce/fetch/pm might be different
+    tracker_key get_partition_mutation_key(
+      const std::optional<std::string_view>& client_id);
+
+    /// Finds the limits applicable to the given quota tracker key
+    quota_limits find_quota_value(const tracker_key&);
+
+    /// `watch` can be used to register for quota changes
+    void watch(on_change_fn&& fn) { _on_change = std::move(fn); };
+
+private:
+    using quota_config
+      = std::unordered_map<ss::sstring, config::client_group_quota>;
+
+    int64_t get_client_target_produce_tp_rate(const tracker_key& quota_id);
+    std::optional<int64_t>
+    get_client_target_fetch_tp_rate(const tracker_key& quota_id);
+
+    config::binding<uint32_t> _default_target_produce_tp_rate;
+    config::binding<std::optional<uint32_t>> _default_target_fetch_tp_rate;
+    config::binding<std::optional<uint32_t>> _target_partition_mutation_quota;
+    config::binding<quota_config> _target_produce_tp_rate_per_client_group;
+    config::binding<quota_config> _target_fetch_tp_rate_per_client_group;
+
+    std::optional<on_change_fn> _on_change;
+};
+
+} // namespace kafka

--- a/src/v/kafka/server/quota_translator.h
+++ b/src/v/kafka/server/quota_translator.h
@@ -47,6 +47,9 @@ struct quota_limits {
     std::optional<uint64_t> produce_limit;
     std::optional<uint64_t> fetch_limit;
     std::optional<uint64_t> partition_mutation_limit;
+
+    friend bool operator==(const quota_limits&, const quota_limits&) = default;
+    friend std::ostream& operator<<(std::ostream& os, const quota_limits& l);
 };
 
 /// quota_translator is responsible for providing quota_manager with a

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ rp_test(
     fetch_unit_test.cc
     config_utils_test.cc
     config_response_utils_test.cc
+    quota_translator_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::kafka
   LABELS kafka

--- a/src/v/kafka/server/tests/quota_manager_test.cc
+++ b/src/v/kafka/server/tests/quota_manager_test.cc
@@ -173,6 +173,8 @@ constexpr auto basic_config = [](config::configuration& conf) {
 };
 
 SEASTAR_THREAD_TEST_CASE(static_config_test) {
+    using k_client_id = kafka::quota_manager::k_client_id;
+    using k_group_name = kafka::quota_manager::k_group_name;
     fixture f;
     f.start().get();
     auto stop = ss::defer([&] { f.stop().get(); });
@@ -186,7 +188,8 @@ SEASTAR_THREAD_TEST_CASE(static_config_test) {
         f.sqm.local().record_fetch_tp(client_id, 1).get();
         f.sqm.local().record_produce_tp_and_throttle(client_id, 1).get();
         f.sqm.local().record_partition_mutations(client_id, 1).get();
-        auto it = f.buckets_map.local()->find(client_id + "-group");
+        auto it = f.buckets_map.local()->find(
+          k_group_name{client_id + "-group"});
         BOOST_REQUIRE(it != f.buckets_map.local()->end());
         BOOST_REQUIRE(it->second->tp_produce_rate.has_value());
         BOOST_CHECK_EQUAL(it->second->tp_produce_rate->rate(), 4096);
@@ -200,7 +203,8 @@ SEASTAR_THREAD_TEST_CASE(static_config_test) {
         f.sqm.local().record_fetch_tp(client_id, 1).get();
         f.sqm.local().record_produce_tp_and_throttle(client_id, 1).get();
         f.sqm.local().record_partition_mutations(client_id, 1).get();
-        auto it = f.buckets_map.local()->find(client_id + "-group");
+        auto it = f.buckets_map.local()->find(
+          k_group_name{client_id + "-group"});
         BOOST_REQUIRE(it != f.buckets_map.local()->end());
         BOOST_REQUIRE(it->second->tp_produce_rate.has_value());
         BOOST_CHECK_EQUAL(it->second->tp_produce_rate->rate(), 2048);
@@ -214,7 +218,7 @@ SEASTAR_THREAD_TEST_CASE(static_config_test) {
         f.sqm.local().record_fetch_tp(client_id, 1).get();
         f.sqm.local().record_produce_tp_and_throttle(client_id, 1).get();
         f.sqm.local().record_partition_mutations(client_id, 1).get();
-        auto it = f.buckets_map.local()->find(client_id);
+        auto it = f.buckets_map.local()->find(k_client_id{client_id});
         BOOST_REQUIRE(it != f.buckets_map.local()->end());
         BOOST_REQUIRE(it->second->tp_produce_rate.has_value());
         BOOST_CHECK_EQUAL(it->second->tp_produce_rate->rate(), 1024);
@@ -227,6 +231,7 @@ SEASTAR_THREAD_TEST_CASE(static_config_test) {
 
 SEASTAR_THREAD_TEST_CASE(update_test) {
     using clock = kafka::quota_manager::clock;
+    using k_group_name = kafka::quota_manager::k_group_name;
     fixture f;
     f.start().get();
     auto stop = ss::defer([&] { f.stop().get(); });
@@ -252,7 +257,8 @@ SEASTAR_THREAD_TEST_CASE(update_test) {
         }).get();
 
         // Check the rate has been updated
-        auto it = f.buckets_map.local()->find(client_id + "-group");
+        auto it = f.buckets_map.local()->find(
+          k_group_name{client_id + "-group"});
         BOOST_REQUIRE(it != f.buckets_map.local()->end());
         BOOST_REQUIRE(it->second->tp_fetch_rate.has_value());
         BOOST_CHECK_EQUAL(it->second->tp_fetch_rate->rate(), 4098);
@@ -288,7 +294,8 @@ SEASTAR_THREAD_TEST_CASE(update_test) {
         }).get();
 
         // Check the rate has been updated
-        auto it = f.buckets_map.local()->find(client_id + "-group");
+        auto it = f.buckets_map.local()->find(
+          k_group_name{client_id + "-group"});
         BOOST_REQUIRE(it != f.buckets_map.local()->end());
         BOOST_REQUIRE(it->second->tp_produce_rate.has_value());
         BOOST_CHECK_EQUAL(it->second->tp_produce_rate->rate(), 1024);

--- a/src/v/kafka/server/tests/quota_manager_test.cc
+++ b/src/v/kafka/server/tests/quota_manager_test.cc
@@ -9,6 +9,7 @@
 
 #include "config/configuration.h"
 #include "kafka/server/quota_manager.h"
+#include "kafka/server/quota_translator.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
@@ -173,8 +174,8 @@ constexpr auto basic_config = [](config::configuration& conf) {
 };
 
 SEASTAR_THREAD_TEST_CASE(static_config_test) {
-    using k_client_id = kafka::quota_manager::k_client_id;
-    using k_group_name = kafka::quota_manager::k_group_name;
+    using k_client_id = kafka::k_client_id;
+    using k_group_name = kafka::k_group_name;
     fixture f;
     f.start().get();
     auto stop = ss::defer([&] { f.stop().get(); });
@@ -231,7 +232,7 @@ SEASTAR_THREAD_TEST_CASE(static_config_test) {
 
 SEASTAR_THREAD_TEST_CASE(update_test) {
     using clock = kafka::quota_manager::clock;
-    using k_group_name = kafka::quota_manager::k_group_name;
+    using k_group_name = kafka::k_group_name;
     fixture f;
     f.start().get();
     auto stop = ss::defer([&] { f.stop().get(); });

--- a/src/v/kafka/server/tests/quota_translator_test.cc
+++ b/src/v/kafka/server/tests/quota_translator_test.cc
@@ -1,0 +1,179 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "base/seastarx.h"
+#include "config/configuration.h"
+#include "kafka/server/quota_translator.h"
+
+#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/test_tools.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <variant>
+
+using namespace kafka;
+
+const tracker_key client_id = k_client_id{"franz-go"};
+
+constexpr std::string_view raw_basic_produce_config = R"([
+  {
+    "group_name": "not-franz-go-produce-group",
+    "clients_prefix": "not-franz-go",
+    "quota": 2048
+  },
+  {
+    "group_name": "franz-go-produce-group",
+    "clients_prefix": "franz-go",
+    "quota": 4096
+  }
+])";
+
+constexpr std::string_view raw_basic_fetch_config = R"([
+  {
+    "group_name": "not-franz-go-fetch-group",
+    "clients_prefix": "not-franz-go",
+    "quota": 2049
+  },
+  {
+    "group_name": "franz-go-fetch-group",
+    "clients_prefix": "franz-go",
+    "quota": 4097
+  }
+])";
+
+BOOST_AUTO_TEST_CASE(quota_translator_default_test) {
+    quota_translator tr;
+
+    auto default_limits = quota_limits{
+      .produce_limit = 2147483648,
+      .fetch_limit = std::nullopt,
+      .partition_mutation_limit = std::nullopt,
+    };
+    BOOST_CHECK_EQUAL(default_limits, tr.find_quota_value(client_id));
+}
+
+BOOST_AUTO_TEST_CASE(quota_translator_modified_default_test) {
+    config::shard_local_cfg().target_quota_byte_rate.set_value(1111);
+    config::shard_local_cfg().target_fetch_quota_byte_rate.set_value(2222);
+    config::shard_local_cfg().kafka_admin_topic_api_rate.set_value(3333);
+
+    quota_translator tr;
+
+    auto expected_limits = quota_limits{
+      .produce_limit = 1111,
+      .fetch_limit = 2222,
+      .partition_mutation_limit = 3333,
+    };
+    BOOST_CHECK_EQUAL(expected_limits, tr.find_quota_value(client_id));
+}
+
+BOOST_AUTO_TEST_CASE(quota_translator_client_group_test) {
+    constexpr auto P_DEF = 1111;
+    constexpr auto F_DEF = 2222;
+    constexpr auto PM_DEF = 3333;
+
+    config::shard_local_cfg().target_quota_byte_rate.set_value(P_DEF);
+    config::shard_local_cfg().target_fetch_quota_byte_rate.set_value(F_DEF);
+    config::shard_local_cfg().kafka_admin_topic_api_rate.set_value(PM_DEF);
+
+    config::shard_local_cfg().kafka_client_group_byte_rate_quota.set_value(
+      YAML::Load(std::string(raw_basic_produce_config)));
+    config::shard_local_cfg()
+      .kafka_client_group_fetch_byte_rate_quota.set_value(
+        YAML::Load(std::string(raw_basic_fetch_config)));
+
+    quota_translator tr;
+
+    // Stage 1 - Start by checking that tracker_key's are correctly detected
+    // for various client ids
+    auto check_key = [](auto expected, auto got) {
+        BOOST_CHECK_EQUAL(expected, get<decltype(expected)>(got));
+    };
+
+    // Check keys for produce
+    check_key(
+      k_group_name{"franz-go-produce-group"}, tr.get_produce_key("franz-go"));
+    check_key(
+      k_group_name{"franz-go-produce-group"}, tr.get_produce_key("franz-go"));
+    check_key(
+      k_group_name{"not-franz-go-produce-group"},
+      tr.get_produce_key("not-franz-go"));
+    check_key(k_client_id{"unknown"}, tr.get_produce_key("unknown"));
+    check_key(k_client_id{""}, tr.get_produce_key(std::nullopt));
+
+    // Check keys for fetch
+    check_key(
+      k_group_name{"franz-go-fetch-group"}, tr.get_fetch_key("franz-go"));
+    check_key(
+      k_group_name{"not-franz-go-fetch-group"},
+      tr.get_fetch_key("not-franz-go"));
+    check_key(k_client_id{"unknown"}, tr.get_fetch_key("unknown"));
+    check_key(k_client_id{""}, tr.get_fetch_key(std::nullopt));
+
+    // Check keys for partition mutations
+    check_key(
+      k_client_id{"franz-go"}, tr.get_partition_mutation_key("franz-go"));
+    check_key(
+      k_client_id{"not-franz-go"},
+      tr.get_partition_mutation_key("not-franz-go"));
+    check_key(k_client_id{"unknown"}, tr.get_partition_mutation_key("unknown"));
+    check_key(k_client_id{""}, tr.get_partition_mutation_key(std::nullopt));
+
+    // Stage 2 - Next verify that the correct quota limits apply to the
+    // various tracker_key's being tested
+    // Check limits for the franz-go groups
+    auto franz_go_produce_limits = quota_limits{
+      .produce_limit = 4096,
+      .fetch_limit = F_DEF,
+      .partition_mutation_limit = PM_DEF,
+    };
+    BOOST_CHECK_EQUAL(
+      franz_go_produce_limits,
+      tr.find_quota_value(k_group_name{"franz-go-produce-group"}));
+    auto franz_go_fetch_limits = quota_limits{
+      .produce_limit = P_DEF,
+      .fetch_limit = 4097,
+      .partition_mutation_limit = PM_DEF,
+    };
+    BOOST_CHECK_EQUAL(
+      franz_go_fetch_limits,
+      tr.find_quota_value(k_group_name{"franz-go-fetch-group"}));
+
+    // Check limits for the not-franz-go groups
+    auto not_franz_go_produce_limits = quota_limits{
+      .produce_limit = 2048,
+      .fetch_limit = F_DEF,
+      .partition_mutation_limit = PM_DEF,
+    };
+    BOOST_CHECK_EQUAL(
+      not_franz_go_produce_limits,
+      tr.find_quota_value(k_group_name{"not-franz-go-produce-group"}));
+    auto not_franz_go_fetch_limits = quota_limits{
+      .produce_limit = P_DEF,
+      .fetch_limit = 2049,
+      .partition_mutation_limit = PM_DEF,
+    };
+    BOOST_CHECK_EQUAL(
+      not_franz_go_fetch_limits,
+      tr.find_quota_value(k_group_name{"not-franz-go-fetch-group"}));
+
+    // Check limits for the non-client-group keys
+    auto default_limits = quota_limits{
+      .produce_limit = P_DEF,
+      .fetch_limit = F_DEF,
+      .partition_mutation_limit = PM_DEF,
+    };
+    BOOST_CHECK_EQUAL(
+      default_limits, tr.find_quota_value(k_client_id{"unknown"}));
+    BOOST_CHECK_EQUAL(default_limits, tr.find_quota_value(k_client_id{""}));
+    BOOST_CHECK_EQUAL(
+      default_limits, tr.find_quota_value(k_client_id{"franz-go"}));
+    BOOST_CHECK_EQUAL(
+      default_limits, tr.find_quota_value(k_client_id{"not-franz-go"}));
+}


### PR DESCRIPTION
This introduces a new class `quota_translator` that handles two things:
* Translating a client id (or more generally a request context) into the `tracker_key` that should be used.
* Finding the quota limits that apply to a `tracker_key`

This code is extracted because while for now `quota_translator` only reads quota configurations from cluster configs, in follow-up PRs we intend to integrate the new `quota_store` into `quota_translator` as well. `quota_translator` is going to handle the merging of these two source of quota configurations.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
